### PR TITLE
CS-491 Support multiple commitment statements for an apprenticeship

### DIFF
--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Bindings/Database.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Bindings/Database.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using SFA.DAS.ApprenticeCommitments.Data.Models;
+using SFA.DAS.ApprenticeCommitments.Extensions;
 using TechTalk.SpecFlow;
 
 namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Bindings
@@ -22,6 +23,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Bindings
             var optionsBuilder = new DbContextOptionsBuilder<ApprenticeCommitmentsDbContext>();
             var options = dbFactory
                 .AddConnection(optionsBuilder)
+                .EnableSensitiveDataLogging()
                 .Options;
             _context.DbContext = new UntrackedApprenticeCommitmentsDbContext(options);
 

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmApprenticeshipSteps.cs
@@ -49,7 +49,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
             };
 
             await _context.Api.Post(
-                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.Id}/ApprenticeshipConfirmation",
+                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.ApprenticeshipId}/ApprenticeshipConfirmation",
                 command);
         }
 
@@ -64,7 +64,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         {
             _context.DbContext.Apprenticeships.Should().ContainEquivalentOf(new
             {
-                _apprenticeship.Id,
+                _apprenticeship.ApprenticeshipId,
                 ApprenticeshipConfirmed,
             });
         }

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmApprenticeshipSteps.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         private readonly Fixture _fixture = new Fixture();
         private readonly TestContext _context;
         private readonly Apprentice _apprentice;
-        private readonly Apprenticeship _apprenticeship;
+        private readonly CommitmentStatement _apprenticeship;
         private bool? ApprenticeshipConfirmed { get; set; }
 
         public ConfirmApprenticeshipSteps(TestContext context)
@@ -23,7 +23,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
             _context = context;
 
             _apprentice = _fixture.Create<Apprentice>();
-            _apprenticeship = _fixture.Create<Apprenticeship>();
+            _apprenticeship = _fixture.Create<CommitmentStatement>();
             _apprentice.AddApprenticeship(_apprenticeship);
         }
 

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmRolesAndResponsibilitiesSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmRolesAndResponsibilitiesSteps.cs
@@ -62,7 +62,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
             };
 
             await _context.Api.Post(
-                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.Id}/RolesAndResponsibilitiesConfirmation",
+                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.ApprenticeshipId}/RolesAndResponsibilitiesConfirmation",
                 command);
         }
 
@@ -83,7 +83,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         {
             _context.DbContext.Apprenticeships.Should().ContainEquivalentOf(new
             {
-                _apprenticeship.Id,
+                _apprenticeship.ApprenticeshipId,
                 RolesAndResponsibilitiesCorrect,
             });
         }

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmRolesAndResponsibilitiesSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmRolesAndResponsibilitiesSteps.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         private readonly Fixture _fixture = new Fixture();
         private readonly TestContext _context;
         private readonly Apprentice _apprentice;
-        private readonly Apprenticeship _apprenticeship;
+        private readonly CommitmentStatement _apprenticeship;
         private bool? RolesAndResponsibilitiesCorrect { get; set; }        
 
         public ConfirmRolesAndResponsibilitiesSteps(TestContext context)
@@ -23,7 +23,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
             _context = context;
 
             _apprentice = _fixture.Create<Apprentice>();
-            _apprenticeship = _fixture.Create<Apprenticeship>();
+            _apprenticeship = _fixture.Create<CommitmentStatement>();
             _apprentice.AddApprenticeship(_apprenticeship);
         }
 

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmTrainingProviderandOrEmployerSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmTrainingProviderandOrEmployerSteps.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         private readonly Fixture _fixture = new Fixture();
         private readonly TestContext _context;
         private readonly Apprentice _apprentice;
-        private readonly Apprenticeship _apprenticeship;
+        private readonly CommitmentStatement _apprenticeship;
         private bool? TrainingProviderCorrect { get; set; }
         private bool? EmployerCorrect { get; set; }
         private bool? ApprenticeshipDetailsCorrect { get; set; }
@@ -29,7 +29,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
             _context = context;
 
             _apprentice = _fixture.Create<Apprentice>();
-            _apprenticeship = _fixture.Create<Apprenticeship>();
+            _apprenticeship = _fixture.Create<CommitmentStatement>();
             _apprentice.AddApprenticeship(_apprenticeship);
         }
 

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmTrainingProviderandOrEmployerSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/ConfirmTrainingProviderandOrEmployerSteps.cs
@@ -131,7 +131,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         public async Task WhenWeSendTheConfirmation()
         {
             await _context.Api.Post(
-                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.Id}/{endpoint}",
+                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.ApprenticeshipId}/{endpoint}",
                 command);
         }
 
@@ -152,7 +152,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         {
             _context.DbContext.Apprenticeships.Should().ContainEquivalentOf(new
             {
-                _apprenticeship.Id,
+                _apprenticeship.ApprenticeshipId,
                 TrainingProviderCorrect,
                 EmployerCorrect,
                 ApprenticeshipDetailsCorrect,

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeship.feature
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeship.feature
@@ -25,3 +25,9 @@ Scenario: When multiple apprenticeships for a given apprentice exists
 	When we try to retrieve the apprenticeship
 	Then the result should return ok
 	And the response should match the expected apprenticeship values
+
+Scenario: When an apprenticeship with multiple commitment statements for a given apprentice exists
+	Given the apprenticeships exists, has many commitment statements, and is associated with this apprentice
+	When we try to retrieve the apprenticeship
+	Then the result should return ok
+	And the response should match the expected apprenticeship values

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeship.feature
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeship.feature
@@ -31,3 +31,4 @@ Scenario: When an apprenticeship with multiple commitment statements for a given
 	When we try to retrieve the apprenticeship
 	Then the result should return ok
 	And the response should match the expected apprenticeship values
+	And all commitment statements should have the same apprenticeship ID

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeship.feature
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeship.feature
@@ -19,3 +19,9 @@ Scenario: When the apprenticeship exists, but not for this apprentice
 	Given the apprenticeship exists, but it's associated with another apprentice
 	When we try to retrieve the apprenticeship
 	Then the result should return NotFound
+
+Scenario: When multiple apprenticeships for a given apprentice exists
+	Given many apprenticeships exists and are associated with this apprentice
+	When we try to retrieve the apprenticeship
+	Then the result should return ok
+	And the response should match the expected apprenticeship values

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
@@ -24,7 +24,8 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             _apprentice = _fixture.Build<Apprentice>().Create();
 
             var startDate = new System.DateTime(2000, 01, 01);
-            _fixture.Inject(new CourseDetails("", 1, null,
+            _fixture.Register(() => new CourseDetails(
+                _fixture.Create("CourseName"), 1, null,
                 startDate, startDate.AddMonths(32)));
 
             _apprenticeship = _fixture.Build<Apprenticeship>()
@@ -38,6 +39,16 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
         [Given(@"the apprenticeship exists and it's associated with this apprentice")]
         public async Task GivenTheApprenticeshipExistsAndItSAssociatedWithThisApprentice()
         {
+            _apprentice.AddApprenticeship(_apprenticeship);
+            _context.DbContext.Apprentices.Add(_apprentice);
+            await _context.DbContext.SaveChangesAsync();
+        }
+
+        [Given("many apprenticeships exists and are associated with this apprentice")]
+        public async Task GivenManyApprenticeshipExistsAndAreAssociatedWithThisApprentice()
+        {
+            _apprentice.AddApprenticeship(_fixture.Create<Apprenticeship>());
+            _apprentice.AddApprenticeship(_fixture.Create<Apprenticeship>());
             _apprentice.AddApprenticeship(_apprenticeship);
             _context.DbContext.Apprentices.Add(_apprentice);
             await _context.DbContext.SaveChangesAsync();

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
@@ -54,6 +54,19 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             await _context.DbContext.SaveChangesAsync();
         }
 
+        [Given("the apprenticeships exists, has many commitment statements, and is associated with this apprentice")]
+        public async Task GivenTheApprenticeshipsExistsHasManyCommitmentStatementsAndIsAssociatedWithThisApprentice()
+        {
+            _apprentice.AddApprenticeship(_apprenticeship);
+            _context.DbContext.Apprentices.Add(_apprentice);
+            await _context.DbContext.SaveChangesAsync();
+
+            _apprenticeship = _apprenticeship.RenewCommitment(_fixture.Create<ApprenticeshipDetails>());
+            _apprentice.AddApprenticeship(_apprenticeship);
+            await _context.DbContext.SaveChangesAsync();
+        }
+
+
         [Given(@"there is no apprenticeship")]
         public void GivenThereIsNoApprenticeship()
         {

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
         private readonly TestContext _context;
         private Fixture _fixture = new Fixture();
         private Apprentice _apprentice;
-        private Apprenticeship _apprenticeship;
+        private CommitmentStatement _apprenticeship;
 
         public GetApprenticeshipSteps(TestContext context)
         {
@@ -30,7 +30,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
                 _fixture.Create("CourseName"), 1, null,
                 startDate, startDate.AddMonths(32)));
 
-            _apprenticeship = _fixture.Build<Apprenticeship>()
+            _apprenticeship = _fixture.Build<CommitmentStatement>()
                 .Do(a => a.ConfirmTrainingProvider(true))
                 .Do(a => a.ConfirmEmployer(true))
                 .Do(a => a.ConfirmApprenticeshipDetails(true))
@@ -49,8 +49,8 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
         [Given("many apprenticeships exists and are associated with this apprentice")]
         public async Task GivenManyApprenticeshipExistsAndAreAssociatedWithThisApprentice()
         {
-            _apprentice.AddApprenticeship(_fixture.Create<Apprenticeship>());
-            _apprentice.AddApprenticeship(_fixture.Create<Apprenticeship>());
+            _apprentice.AddApprenticeship(_fixture.Create<CommitmentStatement>());
+            _apprentice.AddApprenticeship(_fixture.Create<CommitmentStatement>());
             _apprentice.AddApprenticeship(_apprenticeship);
             _context.DbContext.Apprentices.Add(_apprentice);
             await _context.DbContext.SaveChangesAsync();

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using SFA.DAS.ApprenticeCommitments.Data.Models;
 using SFA.DAS.ApprenticeCommitments.DTOs;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using TechTalk.SpecFlow;
@@ -118,6 +119,15 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             a.PlannedStartDate.Should().Be(_apprenticeship.Details.Course.PlannedStartDate);
             a.PlannedEndDate.Should().Be(_apprenticeship.Details.Course.PlannedEndDate);
             a.DurationInMonths.Should().Be(32 + 1); // Duration is inclusive of start and end months
+        }
+
+        [Then("all commitment statements should have the same apprenticeship ID")]
+        public async Task ThenAllCommitmentStatementsShouldHaveTheSameApprenticeshipID()
+        {
+            var apprentice = await _context.DbContext.Apprentices.FindAsync(_apprentice.Id);
+            apprentice.Apprenticeships
+                .Should().NotBeEmpty()
+                .And.OnlyContain(a => a.Id == _apprenticeship.Id);
         }
 
         [Then(@"the result should return NotFound")]

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using SFA.DAS.ApprenticeCommitments.Data.Models;
 using SFA.DAS.ApprenticeCommitments.DTOs;
@@ -89,7 +90,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
         [When(@"we try to retrieve the apprenticeship")]
         public async Task WhenWeTryToRetrieveTheApprenticeship()
         {
-            await _context.Api.Get($"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.Id}");
+            await _context.Api.Get($"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.ApprenticeshipId}");
         }
 
         [Then(@"the result should return ok")]
@@ -104,7 +105,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             var content = await _context.Api.Response.Content.ReadAsStringAsync();
             var a = JsonConvert.DeserializeObject<ApprenticeshipDto>(content);
             a.Should().NotBeNull();
-            a.Id.Should().Be(_apprenticeship.Id);
+            a.Id.Should().Be(_apprenticeship.ApprenticeshipId);
             a.CommitmentsApprenticeshipId.Should().Be(_apprenticeship.CommitmentsApprenticeshipId);
             a.EmployerName.Should().Be(_apprenticeship.Details.EmployerName);
             a.EmployerAccountLegalEntityId.Should().Be(_apprenticeship.Details.EmployerAccountLegalEntityId);
@@ -127,7 +128,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             var apprentice = await _context.DbContext.Apprentices.FindAsync(_apprentice.Id);
             apprentice.Apprenticeships
                 .Should().NotBeEmpty()
-                .And.OnlyContain(a => a.Id == _apprenticeship.Id);
+                .And.OnlyContain(a => a.ApprenticeshipId == _apprenticeship.ApprenticeshipId);
         }
 
         [Then(@"the result should return NotFound")]

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
@@ -1,6 +1,5 @@
 ﻿using AutoFixture;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using SFA.DAS.ApprenticeCommitments.Data.Models;
 using SFA.DAS.ApprenticeCommitments.DTOs;
@@ -49,6 +48,10 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
         [Given("many apprenticeships exists and are associated with this apprentice")]
         public async Task GivenManyApprenticeshipExistsAndAreAssociatedWithThisApprentice()
         {
+            // Ensure previous approvals happened before the one we will later assert on, so 
+            // the GetApprenticeship feature finds our one as the latest approval
+            _fixture.Register((int i) => _apprenticeship.ApprovedOn.AddDays(-i));
+            
             _apprentice.AddApprenticeship(_fixture.Create<CommitmentStatement>());
             _apprentice.AddApprenticeship(_fixture.Create<CommitmentStatement>());
             _apprentice.AddApprenticeship(_apprenticeship);

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipSteps.cs
@@ -61,7 +61,9 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             _context.DbContext.Apprentices.Add(_apprentice);
             await _context.DbContext.SaveChangesAsync();
 
-            _apprenticeship = _apprenticeship.RenewCommitment(_fixture.Create<ApprenticeshipDetails>());
+            _apprenticeship = _apprenticeship.RenewCommitment(
+                _fixture.Create<ApprenticeshipDetails>(),
+                _apprenticeship.ApprovedOn.AddDays(1));
             _apprentice.AddApprenticeship(_apprenticeship);
             await _context.DbContext.SaveChangesAsync();
         }

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipsSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipsSteps.cs
@@ -60,7 +60,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             var response = JsonConvert.DeserializeObject<List<ApprenticeshipDto>>(content);
             response.Should().BeEquivalentTo(_apprentice.Apprenticeships.Select(a => new
             {
-                a.Id,
+                Id = a.ApprenticeshipId,
                 a.CommitmentsApprenticeshipId,
             }));
         }

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipsSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/GetApprenticeshipsSteps.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
 
             _apprentice = _fixture.Build<Apprentice>()
                 .Create();
-            _apprentice.AddApprenticeship(_fixture.Create<Apprenticeship>());
+            _apprentice.AddApprenticeship(_fixture.Create<CommitmentStatement>());
         }
 
         [Given("there is one apprenticeship")]

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/HowApprenticeshipWillBeDeliveredSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/HowApprenticeshipWillBeDeliveredSteps.cs
@@ -15,14 +15,14 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         private readonly Fixture _fixture = new Fixture();
         private readonly TestContext _context;
         private readonly Apprentice _apprentice;
-        private readonly Apprenticeship _apprenticeship;
+        private readonly CommitmentStatement _apprenticeship;
         private bool? HowApprenticeshipDeliveredCorrect { get; set; }
 
         public HowApprenticeshipWillBeDeliveredSteps(TestContext context)
         {
             _context = context;
             _apprentice = _fixture.Create<Apprentice>();
-            _apprenticeship = _fixture.Create<Apprenticeship>();
+            _apprenticeship = _fixture.Create<CommitmentStatement>();
             _apprentice.AddApprenticeship(_apprenticeship);
         }
 

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/HowApprenticeshipWillBeDeliveredSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/HowApprenticeshipWillBeDeliveredSteps.cs
@@ -57,7 +57,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         {
 
             await _context.Api.Post(
-                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.Id}/howapprenticeshipwillbedeliveredconfirmation",
+                $"apprentices/{_apprentice.Id}/apprenticeships/{_apprenticeship.ApprenticeshipId}/howapprenticeshipwillbedeliveredconfirmation",
                 new HowApprenticeshipWillBeDeliveredRequest
                 {
                     HowApprenticeshipDeliveredCorrect = (bool)HowApprenticeshipDeliveredCorrect,
@@ -75,7 +75,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Features
         {
             _context.DbContext.Apprenticeships.Should().ContainEquivalentOf(new
             {
-                _apprenticeship.Id,
+                _apprenticeship.ApprenticeshipId,
                 HowApprenticeshipDeliveredCorrect
             });
         }

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.csproj
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.csproj
@@ -5,10 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.15.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.SeedExtensions" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="SpecFlow" Version="3.5.5" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.5.5" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.5.5" />

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/TestsConnectionFactory.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/TestsConnectionFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.Sqlite;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using SFA.DAS.ApprenticeCommitments.Data.Models;
 using SFA.DAS.ApprenticeCommitments.Infrastructure;
@@ -108,6 +108,11 @@ To ensure that we are testing against the real database schema used in productio
 
 Instead, manually deploy the database using the `SFA.DAS.ApprenticeCommitments.Database` project, targetting `SFA.DAS.ApprenticeCommitments.AcceptanceTests`");
             }
+
+            dbContext.Database.ExecuteSqlRaw("truncate table Apprenticeship");
+            dbContext.Database.ExecuteSqlRaw("truncate table ApprenticeEmailAddressHistory");
+            dbContext.Database.ExecuteSqlRaw("truncate table Registration");
+            dbContext.Database.ExecuteSqlRaw("delete from Apprentice");
         }
 
         public void EnsureDeleted(ApprenticeCommitmentsDbContext dbContext)

--- a/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.refactorlog
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.refactorlog
@@ -112,4 +112,11 @@
     <Property Name="ParentElementType" Value="SqlTable" />
     <Property Name="NewName" Value="PlannedEndDate" />
   </Operation>
+  <Operation Name="Rename Refactor" Key="ae4ba87f-74c6-4107-8fb0-73137b01738a" ChangeDateTime="04/26/2021 05:11:29">
+    <Property Name="ElementName" Value="[dbo].[Apprenticeship].[CreatedOn]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Apprenticeship]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="ApprovedOn" />
+  </Operation>
 </Operations>

--- a/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.refactorlog
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.refactorlog
@@ -133,4 +133,11 @@
     <Property Name="ParentElementType" Value="SqlTable" />
     <Property Name="NewName" Value="Id" />
   </Operation>
+  <Operation Name="Rename Refactor" Key="c0956a66-2dd2-4a0c-9e78-08765538c841" ChangeDateTime="04/29/2021 05:23:15">
+    <Property Name="ElementName" Value="[dbo].[Apprenticeship]" />
+    <Property Name="ElementType" Value="SqlTable" />
+    <Property Name="ParentElementName" Value="[dbo]" />
+    <Property Name="ParentElementType" Value="SqlSchema" />
+    <Property Name="NewName" Value="[CommitmentStatement]" />
+  </Operation>
 </Operations>

--- a/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.refactorlog
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.refactorlog
@@ -119,4 +119,18 @@
     <Property Name="ParentElementType" Value="SqlTable" />
     <Property Name="NewName" Value="ApprovedOn" />
   </Operation>
+  <Operation Name="Rename Refactor" Key="7505027b-c80c-4012-986f-2afa844a5127" ChangeDateTime="04/29/2021 05:17:52">
+    <Property Name="ElementName" Value="[dbo].[Apprenticeship].[Id]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Apprenticeship]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="ApprenticeshipId" />
+  </Operation>
+  <Operation Name="Rename Refactor" Key="752d6dad-2d75-47ba-b29c-aab79ad71dd5" ChangeDateTime="04/29/2021 05:17:58">
+    <Property Name="ElementName" Value="[dbo].[Apprenticeship].[UniqueId]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Apprenticeship]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="Id" />
+  </Operation>
 </Operations>

--- a/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.sqlproj
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.sqlproj
@@ -63,7 +63,7 @@
     <Build Include="Tables\ClientOutboxData.sql" />
     <Build Include="Tables\OutboxData.sql" />
     <Build Include="Tables\Apprentice.sql" />
-    <Build Include="Tables\Apprenticeship.sql" />
+    <Build Include="Tables\CommitmentStatement.sql" />
     <Build Include="Tables\ApprenticeEmailAddressHistory.sql" />
     <Build Include="Tables\ApprenticeshipIdNumbers.sql" />
   </ItemGroup>

--- a/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.sqlproj
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/SFA.DAS.ApprenticeCommitments.Database.sqlproj
@@ -65,6 +65,7 @@
     <Build Include="Tables\Apprentice.sql" />
     <Build Include="Tables\Apprenticeship.sql" />
     <Build Include="Tables\ApprenticeEmailAddressHistory.sql" />
+    <Build Include="Tables\ApprenticeshipIdNumbers.sql" />
   </ItemGroup>
   <ItemGroup>
     <RefactorLog Include="SFA.DAS.ApprenticeCommitments.Database.refactorlog" />

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
@@ -4,6 +4,7 @@ CREATE TABLE [dbo].[Apprenticeship]
 	[Id] BIGINT NOT NULL,
 	[ApprenticeId] UNIQUEIDENTIFIER NOT NULL, 
     [CommitmentsApprenticeshipId] BIGINT NOT NULL,
+    [ApprovedOn] DATETIME2 NOT NULL DEFAULT GetUtcDate(), 
 	[EmployerAccountLegalEntityId] BIGINT NOT NULL,
 	[EmployerName] NVARCHAR(100) NOT NULL, 
     [TrainingProviderId] BIGINT NOT NULL, 
@@ -19,8 +20,8 @@ CREATE TABLE [dbo].[Apprenticeship]
     [ApprenticeshipDetailsCorrect] bit NULL,
     [HowApprenticeshipDeliveredCorrect] BIT NULL, 
     [ApprenticeshipConfirmed] bit NULL,
-    [CreatedOn] DATETIME2 NOT NULL DEFAULT GetUtcDate(), 
     CONSTRAINT PK_Apprenticeship_UniqueId PRIMARY KEY CLUSTERED ([UniqueId]),
+    CONSTRAINT PK_Apprenticeship_ID_CommitmentsApprenticeshipId_CreatedOn UNIQUE ([Id], [CommitmentsApprenticeshipId], [ApprovedOn]),
 	CONSTRAINT FK_Apprenticeship_ApprenticeId FOREIGN KEY ([ApprenticeId]) REFERENCES [dbo].[Apprentice] ([Id])
 )
 

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [dbo].[Apprenticeship]
 (
-    [UniqueId] BIGINT IDENTITY(1,1) NOT NULL, 
-	[Id] BIGINT NOT NULL CONSTRAINT DF_Apprenticeship_Id default next value for ApprenticeshipIdNumbers,
+    [Id] BIGINT IDENTITY(1,1) NOT NULL, 
+	[ApprenticeshipId] BIGINT NOT NULL CONSTRAINT DF_Apprenticeship_Id default next value for ApprenticeshipIdNumbers,
 	[ApprenticeId] UNIQUEIDENTIFIER NOT NULL, 
     [CommitmentsApprenticeshipId] BIGINT NOT NULL,
     [ApprovedOn] DATETIME2 NOT NULL DEFAULT GetUtcDate(), 
@@ -20,8 +20,8 @@ CREATE TABLE [dbo].[Apprenticeship]
     [ApprenticeshipDetailsCorrect] bit NULL,
     [HowApprenticeshipDeliveredCorrect] BIT NULL, 
     [ApprenticeshipConfirmed] bit NULL,
-    CONSTRAINT PK_Apprenticeship_UniqueId PRIMARY KEY CLUSTERED ([UniqueId]),
-    CONSTRAINT PK_Apprenticeship_ID_CommitmentsApprenticeshipId_CreatedOn UNIQUE ([Id], [CommitmentsApprenticeshipId], [ApprovedOn]),
+    CONSTRAINT PK_Apprenticeship_UniqueId PRIMARY KEY CLUSTERED ([Id]),
+    CONSTRAINT PK_Apprenticeship_ID_CommitmentsApprenticeshipId_CreatedOn UNIQUE ([ApprenticeshipId], [CommitmentsApprenticeshipId], [ApprovedOn]),
 	CONSTRAINT FK_Apprenticeship_ApprenticeId FOREIGN KEY ([ApprenticeId]) REFERENCES [dbo].[Apprentice] ([Id])
 )
 

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
@@ -1,4 +1,4 @@
-﻿CREATE TABLE [dbo].[Apprenticeship]
+CREATE TABLE [dbo].[Apprenticeship]
 (
 	[Id] BIGINT IDENTITY(10000,1) NOT NULL,
 	[ApprenticeId] UNIQUEIDENTIFIER NOT NULL, 
@@ -18,6 +18,7 @@
     [ApprenticeshipDetailsCorrect] bit NULL,
     [HowApprenticeshipDeliveredCorrect] BIT NULL, 
     [ApprenticeshipConfirmed] bit NULL,
+    [CreatedOn] DATETIME2 NOT NULL DEFAULT GetUtcDate(), 
     CONSTRAINT PK_Apprenticeship_Id PRIMARY KEY CLUSTERED ([Id]),
 	CONSTRAINT FK_Apprenticeship_ApprenticeId FOREIGN KEY ([ApprenticeId]) REFERENCES [dbo].[Apprentice] ([Id])
 )

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
@@ -1,6 +1,7 @@
 CREATE TABLE [dbo].[Apprenticeship]
 (
-	[Id] BIGINT IDENTITY(10000,1) NOT NULL,
+    [UniqueId] BIGINT IDENTITY(1,1) NOT NULL, 
+	[Id] BIGINT NOT NULL,
 	[ApprenticeId] UNIQUEIDENTIFIER NOT NULL, 
     [CommitmentsApprenticeshipId] BIGINT NOT NULL,
 	[EmployerAccountLegalEntityId] BIGINT NOT NULL,
@@ -19,7 +20,7 @@ CREATE TABLE [dbo].[Apprenticeship]
     [HowApprenticeshipDeliveredCorrect] BIT NULL, 
     [ApprenticeshipConfirmed] bit NULL,
     [CreatedOn] DATETIME2 NOT NULL DEFAULT GetUtcDate(), 
-    CONSTRAINT PK_Apprenticeship_Id PRIMARY KEY CLUSTERED ([Id]),
+    CONSTRAINT PK_Apprenticeship_UniqueId PRIMARY KEY CLUSTERED ([UniqueId]),
 	CONSTRAINT FK_Apprenticeship_ApprenticeId FOREIGN KEY ([ApprenticeId]) REFERENCES [dbo].[Apprentice] ([Id])
 )
 

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Apprenticeship.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [dbo].[Apprenticeship]
 (
     [UniqueId] BIGINT IDENTITY(1,1) NOT NULL, 
-	[Id] BIGINT NOT NULL,
+	[Id] BIGINT NOT NULL CONSTRAINT DF_Apprenticeship_Id default next value for ApprenticeshipIdNumbers,
 	[ApprenticeId] UNIQUEIDENTIFIER NOT NULL, 
     [CommitmentsApprenticeshipId] BIGINT NOT NULL,
     [ApprovedOn] DATETIME2 NOT NULL DEFAULT GetUtcDate(), 

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/ApprenticeshipIdNumbers.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/ApprenticeshipIdNumbers.sql
@@ -1,0 +1,7 @@
+﻿create sequence [dbo].[ApprenticeshipIdNumbers]
+		as bigint
+		start with 1
+		increment by 1
+		no maxvalue
+		no cycle
+		cache 10

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/CommitmentStatement.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/CommitmentStatement.sql
@@ -1,4 +1,4 @@
-CREATE TABLE [dbo].[Apprenticeship]
+CREATE TABLE [dbo].[CommitmentStatement]
 (
     [Id] BIGINT IDENTITY(1,1) NOT NULL, 
 	[ApprenticeshipId] BIGINT NOT NULL CONSTRAINT DF_Apprenticeship_Id default next value for ApprenticeshipIdNumbers,
@@ -27,7 +27,7 @@ CREATE TABLE [dbo].[Apprenticeship]
 
 GO
 
-CREATE NONCLUSTERED INDEX [IX_Apprenticeship_ApprenticeId] ON [dbo].[Apprenticeship]
+CREATE NONCLUSTERED INDEX [IX_Apprenticeship_ApprenticeId] ON [dbo].[CommitmentStatement]
 (
 	[ApprenticeId] ASC
 )

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Registration.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Registration.sql
@@ -1,7 +1,8 @@
-﻿CREATE TABLE [dbo].[Registration]
+CREATE TABLE [dbo].[Registration]
 (
     [ApprenticeId] UNIQUEIDENTIFIER NOT NULL,
     [ApprenticeshipId] BIGINT NOT NULL, 
+    [ApprovedOn] DATETIME2 NOT NULL, 
     [Email] NVARCHAR(150) NOT NULL, 
     [UserIdentityId] UNIQUEIDENTIFIER NULL,
     [CreatedOn] DATETIME2 NOT NULL DEFAULT current_timestamp,

--- a/src/SFA.DAS.ApprenticeCommitments.UnitTests/SFA.DAS.ApprenticeCommitments.UnitTests.csproj
+++ b/src/SFA.DAS.ApprenticeCommitments.UnitTests/SFA.DAS.ApprenticeCommitments.UnitTests.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.15.0" />
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.15.0" />
-    <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.NUnit3" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateRegistrationCommand/CreateRegistrationCommand.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateRegistrationCommand/CreateRegistrationCommand.cs
@@ -7,6 +7,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Commands.CreateRegistrationC
     {
         public Guid ApprenticeId { get; set; }
         public long ApprenticeshipId { get; set; }
+        public DateTime ApprovedOn { get; set; }
         public string Email { get; set; }
         public string EmployerName { get; set; }
         public long EmployerAccountLegalEntityId { get; set; }

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateRegistrationCommand/CreateRegistrationCommandHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateRegistrationCommand/CreateRegistrationCommandHandler.cs
@@ -19,6 +19,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Commands.CreateRegistrationC
             await _registrations.AddAsync(new Registration(
                 command.ApprenticeId,
                 command.ApprenticeshipId,
+                command.ApprovedOn,
                 new MailAddress(command.Email),
                 new ApprenticeshipDetails(
                     command.EmployerAccountLegalEntityId,

--- a/src/SFA.DAS.ApprenticeCommitments/DTOs/ApprenticeshipDtoMapping.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/DTOs/ApprenticeshipDtoMapping.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.ApprenticeCommitments.DTOs
 
             return new ApprenticeshipDto
             {
-                Id = apprenticeship.Id,
+                Id = apprenticeship.ApprenticeshipId,
                 CommitmentsApprenticeshipId = apprenticeship.CommitmentsApprenticeshipId,
                 EmployerName = apprenticeship.Details.EmployerName,
                 EmployerAccountLegalEntityId = apprenticeship.Details.EmployerAccountLegalEntityId,

--- a/src/SFA.DAS.ApprenticeCommitments/DTOs/ApprenticeshipDtoMapping.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/DTOs/ApprenticeshipDtoMapping.cs
@@ -6,7 +6,7 @@ namespace SFA.DAS.ApprenticeCommitments.DTOs
 {
     public static class ApprenticeshipDtoMapping
     {
-        public static ApprenticeshipDto? MapToApprenticeshipDto(this Apprenticeship? apprenticeship)
+        public static ApprenticeshipDto? MapToApprenticeshipDto(this CommitmentStatement? apprenticeship)
         {
             if (apprenticeship == null) return null;
 

--- a/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
@@ -22,8 +22,10 @@ namespace SFA.DAS.ApprenticeCommitments.Data
 
         internal async Task<Apprenticeship?> Find(Guid apprenticeId, long apprenticeshipId)
             => await Entities
-                .SingleOrDefaultAsync(
+                .Where(
                     a => a.Id == apprenticeshipId &&
-                    a.Apprentice.Id == apprenticeId);
+                    a.Apprentice.Id == apprenticeId)
+                .OrderByDescending(x => x.CreatedOn)
+                .FirstOrDefaultAsync();
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data
         internal async Task<Apprenticeship?> Find(Guid apprenticeId, long apprenticeshipId)
             => await Entities
                 .Where(
-                    a => a.Id == apprenticeshipId &&
+                    a => a.ApprenticeshipId == apprenticeshipId &&
                     a.Apprentice.Id == apprenticeId)
                 .OrderByDescending(x => x.ApprovedOn)
                 .FirstOrDefaultAsync();

--- a/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data
                 .Where(
                     a => a.Id == apprenticeshipId &&
                     a.Apprentice.Id == apprenticeId)
-                .OrderByDescending(x => x.CreatedOn)
+                .OrderByDescending(x => x.ApprovedOn)
                 .FirstOrDefaultAsync();
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/IApprenticeshipContext.cs
@@ -10,17 +10,17 @@ using System.Threading.Tasks;
 
 namespace SFA.DAS.ApprenticeCommitments.Data
 {
-    public interface IApprenticeshipContext : IEntityContext<Apprenticeship>
+    public interface IApprenticeshipContext : IEntityContext<CommitmentStatement>
     {
-        internal async Task<List<Apprenticeship>> FindByApprenticeId(Guid apprenticeId)
+        internal async Task<List<CommitmentStatement>> FindByApprenticeId(Guid apprenticeId)
             => await Entities.Where(a => a.Apprentice.Id == apprenticeId).ToListAsync();
 
-        internal async Task<Apprenticeship> GetById(Guid apprenticeId, long apprenticeshipId)
+        internal async Task<CommitmentStatement> GetById(Guid apprenticeId, long apprenticeshipId)
             => (await Find(apprenticeId, apprenticeshipId))
                 ?? throw new DomainException(
                     $"Apprenticeship {apprenticeshipId} for {apprenticeId} not found");
 
-        internal async Task<Apprenticeship?> Find(Guid apprenticeId, long apprenticeshipId)
+        internal async Task<CommitmentStatement?> Find(Guid apprenticeId, long apprenticeshipId)
             => await Entities
                 .Where(
                     a => a.ApprenticeshipId == apprenticeshipId &&

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprentice.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprentice.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
 
         public Guid Id { get; private set; }
 
-        public void AddApprenticeship(Apprenticeship apprenticeship)
+        public void AddApprenticeship(CommitmentStatement apprenticeship)
         {
             Apprenticeships.Add(apprenticeship);
         }
@@ -34,8 +34,8 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         public ICollection<ApprenticeEmailAddressHistory> PreviousEmailAddresses { get; private set; }
         public DateTime DateOfBirth { get; private set; }
 
-        public ICollection<Apprenticeship> Apprenticeships { get; private set; }
-            = new List<Apprenticeship>();
+        public ICollection<CommitmentStatement> Apprenticeships { get; private set; }
+            = new List<CommitmentStatement>();
 
         public DateTime CreatedOn { get; private set; } = DateTime.UtcNow;
 

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
@@ -16,11 +16,11 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
 
         public virtual DbSet<Registration> Registrations { get; set; }
         public virtual DbSet<Apprentice> Apprentices { get; set; }
-        public virtual DbSet<Apprenticeship> Apprenticeships { get; set; }
+        public virtual DbSet<CommitmentStatement> Apprenticeships { get; set; }
 
         DbSet<Registration> IEntityContext<Registration>.Entities => Registrations;
         DbSet<Apprentice> IEntityContext<Apprentice>.Entities => Apprentices;
-        DbSet<Apprenticeship> IEntityContext<Apprenticeship>.Entities => Apprenticeships;
+        DbSet<CommitmentStatement> IEntityContext<CommitmentStatement>.Entities => Apprenticeships;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -48,14 +48,14 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
                 a.Property(e => e.CreatedOn).Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Ignore);
             });
 
-            modelBuilder.Entity<Apprenticeship>(a =>
+            modelBuilder.Entity<CommitmentStatement>(a =>
             {
                 a.Property(typeof(long), "Id");
                 a.HasKey("Id");
                 a.Property(e => e.ApprenticeshipId).HasDefaultValue(0);
             });
 
-            modelBuilder.Entity<Apprenticeship>()
+            modelBuilder.Entity<CommitmentStatement>()
                 .OwnsOne(e => e.Details, details =>
                 {
                     details.Property(p => p.EmployerAccountLegalEntityId).HasColumnName("EmployerAccountLegalEntityId");

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
@@ -50,9 +50,9 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
 
             modelBuilder.Entity<Apprenticeship>(a =>
             {
-                a.Property(typeof(long), "UniqueId");
-                a.HasKey("UniqueId");
-                a.Property(e => e.Id).HasDefaultValue(0);
+                a.Property(typeof(long), "Id");
+                a.HasKey("Id");
+                a.Property(e => e.ApprenticeshipId).HasDefaultValue(0);
             });
 
             modelBuilder.Entity<Apprenticeship>()

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
@@ -48,8 +48,11 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
                 a.Property(e => e.CreatedOn).Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Ignore);
             });
 
-            modelBuilder.Entity<Apprenticeship>()
-                .HasKey(a => a.Id);
+            modelBuilder.Entity<Apprenticeship>(a =>
+            {
+                a.Property(typeof(long), "UniqueId");
+                a.HasKey("UniqueId");
+            });
 
             modelBuilder.Entity<Apprenticeship>()
                 .OwnsOne(e => e.Details, details =>

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/ApprenticeCommitmentsDbContext.cs
@@ -52,6 +52,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             {
                 a.Property(typeof(long), "UniqueId");
                 a.HasKey("UniqueId");
+                a.Property(e => e.Id).HasDefaultValue(0);
             });
 
             modelBuilder.Entity<Apprenticeship>()
@@ -74,7 +75,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             modelBuilder.Entity<Registration>(entity =>
             {
                 entity.HasKey(e => e.ApprenticeId);
-                
+
                 entity.Property(e => e.CreatedOn).Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Ignore);
                 entity.Property(e => e.Email)
                     .HasConversion(
@@ -84,7 +85,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
 
             modelBuilder.Entity<Registration>(entity =>
             {
-                entity.Property(e=>e.CreatedOn).Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Ignore);
+                entity.Property(e => e.CreatedOn).Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Ignore);
                 entity.OwnsOne(e => e.Apprenticeship, apprenticeship =>
                 {
                     apprenticeship.Property(p => p.EmployerAccountLegalEntityId)

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             Details = details;
         }
 
-        public long Id { get; private set; } = 0;
+        public long ApprenticeshipId { get; private set; } = 0;
         public long CommitmentsApprenticeshipId { get; private set; }
         public Apprentice Apprentice { get; private set; }
         public ApprenticeshipDetails Details { get; private set; }
@@ -71,7 +71,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         {
             return new Apprenticeship
             {
-                Id = Id,
+                ApprenticeshipId = ApprenticeshipId,
                 CommitmentsApprenticeshipId = CommitmentsApprenticeshipId,
                 ApprovedOn = approvedOn,
                 Details = updatedDetails,

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
@@ -17,9 +17,11 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         }
 
         public Apprenticeship(long commitmentsApprenticeshipId,
+            DateTime approvedOn,
             ApprenticeshipDetails details)
         {
             CommitmentsApprenticeshipId = commitmentsApprenticeshipId;
+            ApprovedOn = approvedOn;
             Details = details;
         }
 
@@ -34,7 +36,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         public bool? ApprenticeshipDetailsCorrect { get; private set; }
         public bool? HowApprenticeshipDeliveredCorrect { get; private set; }
         public bool? ApprenticeshipConfirmed { get; private set; }
-        public DateTime CreatedOn { get; private set; } = DateTime.Now;
+        public DateTime ApprovedOn { get; private set; }
 
         public void ConfirmTrainingProvider(bool trainingProviderCorrect)
         {
@@ -66,12 +68,13 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             ApprenticeshipConfirmed = apprenticeshipCorrect;
         }
 
-        public Apprenticeship RenewCommitment(ApprenticeshipDetails updatedDetails)
+        public Apprenticeship RenewCommitment(ApprenticeshipDetails updatedDetails, DateTime approvedOn)
         {
             return new Apprenticeship
             {
                 Id = Id,
                 CommitmentsApprenticeshipId = CommitmentsApprenticeshipId,
+                ApprovedOn = approvedOn,
                 Details = updatedDetails,
             };
         }

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
@@ -8,7 +8,6 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
     [Table("Apprenticeship")]
     public class Apprenticeship
     {
-        private static long TempSequenceNumber = 10_000;
 #pragma warning disable CS8618 // Constructor for Entity Framework
 
         private Apprenticeship()
@@ -25,7 +24,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             Details = details;
         }
 
-        public long Id { get; private set; } = TempSequenceNumber++;
+        public long Id { get; private set; } = 0;
         public long CommitmentsApprenticeshipId { get; private set; }
         public Apprentice Apprentice { get; private set; }
         public ApprenticeshipDetails Details { get; private set; }

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
@@ -8,6 +8,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
     [Table("Apprenticeship")]
     public class Apprenticeship
     {
+        private static long TempSequenceNumber = 10_000;
 #pragma warning disable CS8618 // Constructor for Entity Framework
 
         private Apprenticeship()
@@ -22,7 +23,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             Details = details;
         }
 
-        public long Id { get; private set; }
+        public long Id { get; private set; } = TempSequenceNumber++;
         public long CommitmentsApprenticeshipId { get; private set; }
         public Apprentice Apprentice { get; private set; }
         public ApprenticeshipDetails Details { get; private set; }
@@ -63,6 +64,16 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         public void ConfirmApprenticeship(bool apprenticeshipCorrect)
         {
             ApprenticeshipConfirmed = apprenticeshipCorrect;
+        }
+
+        public Apprenticeship RenewCommitment(ApprenticeshipDetails updatedDetails)
+        {
+            return new Apprenticeship
+            {
+                Id = Id,
+                CommitmentsApprenticeshipId = CommitmentsApprenticeshipId,
+                Details = updatedDetails,
+            };
         }
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Apprenticeship.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
 
 #nullable enable
 
@@ -32,6 +33,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         public bool? ApprenticeshipDetailsCorrect { get; private set; }
         public bool? HowApprenticeshipDeliveredCorrect { get; private set; }
         public bool? ApprenticeshipConfirmed { get; private set; }
+        public DateTime CreatedOn { get; private set; } = DateTime.Now;
 
         public void ConfirmTrainingProvider(bool trainingProviderCorrect)
         {

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/CommitmentStatement.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/CommitmentStatement.cs
@@ -5,17 +5,17 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace SFA.DAS.ApprenticeCommitments.Data.Models
 {
-    [Table("Apprenticeship")]
-    public class Apprenticeship
+    [Table("CommitmentStatement")]
+    public class CommitmentStatement
     {
 #pragma warning disable CS8618 // Constructor for Entity Framework
 
-        private Apprenticeship()
+        private CommitmentStatement()
 #pragma warning restore CS8618
         {
         }
 
-        public Apprenticeship(long commitmentsApprenticeshipId,
+        public CommitmentStatement(long commitmentsApprenticeshipId,
             DateTime approvedOn,
             ApprenticeshipDetails details)
         {
@@ -67,9 +67,9 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             ApprenticeshipConfirmed = apprenticeshipCorrect;
         }
 
-        public Apprenticeship RenewCommitment(ApprenticeshipDetails updatedDetails, DateTime approvedOn)
+        public CommitmentStatement RenewCommitment(ApprenticeshipDetails updatedDetails, DateTime approvedOn)
         {
-            return new Apprenticeship
+            return new CommitmentStatement
             {
                 ApprenticeshipId = ApprenticeshipId,
                 CommitmentsApprenticeshipId = CommitmentsApprenticeshipId,

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Registration.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Registration.cs
@@ -20,11 +20,13 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         public Registration(
             Guid apprenticeId,
             long apprenticeshipId,
+            DateTime approvedOn,
             MailAddress email,
             ApprenticeshipDetails apprenticeship)
         {
             ApprenticeId = apprenticeId;
             ApprenticeshipId = apprenticeshipId;
+            ApprovedOn = approvedOn;
             Email = email;
             Apprenticeship = apprenticeship;
         }
@@ -34,6 +36,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
         public MailAddress Email { get; private set; }
         public Guid? UserIdentityId { get; private set; }
         public ApprenticeshipDetails Apprenticeship { get; private set; }
+        public DateTime ApprovedOn { get; private set; }
         public DateTime? CreatedOn { get; private set; } = DateTime.UtcNow;
         public DateTime? FirstViewedOn { get; private set; }
         public DateTime? SignUpReminderSentOn { get; private set; }
@@ -87,7 +90,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             var apprentice = new Apprentice(
                 ApprenticeId, firstName, lastName, emailAddress, dateOfBirth);
 
-            apprentice.AddApprenticeship(new Apprenticeship(ApprenticeshipId, Apprenticeship));
+            apprentice.AddApprenticeship(new Apprenticeship(ApprenticeshipId, ApprovedOn, Apprenticeship));
 
             return apprentice;
         }

--- a/src/SFA.DAS.ApprenticeCommitments/Data/Models/Registration.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/Models/Registration.cs
@@ -90,7 +90,7 @@ namespace SFA.DAS.ApprenticeCommitments.Data.Models
             var apprentice = new Apprentice(
                 ApprenticeId, firstName, lastName, emailAddress, dateOfBirth);
 
-            apprentice.AddApprenticeship(new Apprenticeship(ApprenticeshipId, ApprovedOn, Apprenticeship));
+            apprentice.AddApprenticeship(new CommitmentStatement(ApprenticeshipId, ApprovedOn, Apprenticeship));
 
             return apprentice;
         }


### PR DESCRIPTION
This is the foundation work to support multiple commitment statements, and change of circumstances.

The data model has been modified to support the [logical model](https://skillsfundingagency.atlassian.net/wiki/spaces/NDL/pages/2918809643/ADC+-+Logical+Data+Model).

![image](https://user-images.githubusercontent.com/201727/116507320-f43bb500-a8b6-11eb-959e-d11e761e1b1c.png)

In order to avoid problematic joins, the Apprenticeship, Map and Commitment Statement have been rolled into one table:

    table CommitmentStatement
    {
        Id bigint identity
        ApprenticeId bigint
        ApprenticeshipId bigint,    --|
        ApprovalsId bigint          --| Composite uniqueness
        ApprovedOn datetime2        --|
        Details 
        ...
    )

(Note that `ApprovalsId` above is actualled called `CommitmentsApprenticeshipId` in the code and database)

The ApprenticeshipId is generated by a sequence number for the first commitment statement.  Subsequent commitment statements are tied to the first one by the same ApprenticeshipId.

This PR only changes the data layer, the API surface remains as it was - exposing "Apprenticeships" to the web.