### PR TITLE
AAD-2104 Add missing security headers

### DIFF
--- a/src/SFA.DAS.ApprenticeCommitments.Api/Startup.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api/Startup.cs
@@ -131,7 +131,19 @@ namespace SFA.DAS.ApprenticeCommitments.Api
             {
                 app.UseDeveloperExceptionPage();
             }
+            else
+            {
+                app.UseHsts();
+            }
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Append("X-Frame-Options", "DENY");
+                context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+                context.Response.Headers.Append("X-Permitted-Cross-Domain-Policies", "none");
+                context.Response.Headers.Append("Content-Security-Policy", "default-src *; script-src *; connect-src *; img-src *; style-src *; object-src *;");
 
+                await next();
+            });
             app.UseProblemDetails();
 
             app.UseSwagger();


### PR DESCRIPTION
Added missing HTTP security headers to `SFA.DAS.ApprenticeCommitments.Api` (`Startup.cs`) to address AAD-2104 pentest findings.

Implemented:
* `UseHsts()` for non-development environments
* `X-Frame-Options: DENY`
* `X-Content-Type-Options: nosniff`
* `X-Permitted-Cross-Domain-Policies: none`
* `Content-Security-Policy`

Testing
* API runs successfully locally
* Swagger loads successfully
* Verified response headers locally using `Invoke-WebRequest`