### PR TITLE
Create NonClustered Index for Email field

### DIFF
--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Registration.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Registration.sql
@@ -37,5 +37,8 @@ GO
 
 CREATE UNIQUE NONCLUSTERED INDEX [IX_Registration_CommitmentsApprenticeshipId]
     ON [dbo].[Registration]([CommitmentsApprenticeshipId]);
+GO
 
+CREATE NONCLUSTERED INDEX [IX_Registration_Email]
+    ON [dbo].[Registration]([Email]);
 GO

--- a/src/SFA.DAS.ApprenticeCommitments/Data/IRegistrationContext.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Data/IRegistrationContext.cs
@@ -33,11 +33,17 @@ namespace SFA.DAS.ApprenticeCommitments.Data
 
         internal Task<List<Registration>> FindByAccountDetails(string firstName, string lastName, DateTime dateOfBirth, CancellationToken cancellationToken)
             => Entities.Where(r =>
-            r.FirstName == firstName && r.LastName == lastName && r.DateOfBirth == dateOfBirth)
+            r.FirstName == firstName && 
+            r.LastName == lastName && 
+            r.DateOfBirth == dateOfBirth &&
+            r.Approval.Course.PlannedStartDate >= DateTime.Today.AddYears(-1))
             .ToListAsync(cancellationToken);
 
         internal Task<List<Registration>> FindByEmail(string email, CancellationToken cancellationToken)
-            => Entities.Where(r => r.EmailAddress == email).ToListAsync(cancellationToken);
+            => Entities.Where(r => 
+            r.EmailAddress == email &&
+            r.Approval.Course.PlannedStartDate >= DateTime.Today.AddYears(-1))
+            .ToListAsync(cancellationToken);
     }
 
     public static class RegistrationContextExtensions


### PR DESCRIPTION
- Create Index on email field
- include date filters for both `FindByEmail` & `FindByAccountDetails` that only look for records within the last year. This greatly reduces the amount of records touched in the database 

