### PR TITLE
update indexes for personal details query - ignore 404's

### DIFF
--- a/src/SFA.DAS.ApprenticeCommitments.Api/Controllers/RegistrationController.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api/Controllers/RegistrationController.cs
@@ -56,9 +56,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.Controllers
         public async Task<IActionResult> GetRegistrationsByAccountDetails(string firstName, string lastName, DateTime dateOfBirth)
         {
             var response = await _mediator.Send(new GetRegistrationByAccountDetailsQuery(
-                firstName, lastName, dateOfBirth));
-
-            if (response.Count == 0) return NotFound();
+                firstName, lastName, dateOfBirth));            
 
             return Ok(response);
         }
@@ -66,10 +64,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.Controllers
         [HttpGet("registrations/email")]
         public async Task<IActionResult> GetRegistrationByEmail(string email)
         {
-            var response = await _mediator.Send(new GetRegistrationByEmailQuery(email));
-
-            if (response.Count == 0) return NotFound();
-
+            var response = await _mediator.Send(new GetRegistrationByEmailQuery(email));           
             return Ok(response);
         }
 

--- a/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Registration.sql
+++ b/src/SFA.DAS.ApprenticeCommitments.Database/Tables/Registration.sql
@@ -42,3 +42,14 @@ GO
 CREATE NONCLUSTERED INDEX [IX_Registration_Email]
     ON [dbo].[Registration]([Email]);
 GO
+
+CREATE NONCLUSTERED INDEX IX_Registration_FindByAccountDetails
+ON dbo.Registration
+(
+    FirstName,
+    LastName,
+    DateOfBirth,
+    PlannedStartDate
+);
+
+GO

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationByEmailQuery/GetRegistrationByEmailQueryHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationByEmailQuery/GetRegistrationByEmailQueryHandler.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Queries.GetRegistrationByEma
         {
             var entity = await _registrationContext.FindByEmail(request.Email, cancellationToken);
 
-            if (entity == null) return new List<Registration>();
+            if (entity == null || entity.Count == 0) return new List<Registration>();
 
             return entity;
         }

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationByEmailQuery/GetRegistrationByEmailQueryHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationByEmailQuery/GetRegistrationByEmailQueryHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.ApprenticeCommitments.Data;
 using SFA.DAS.ApprenticeCommitments.Data.Models;
 using System.Collections.Generic;
@@ -10,15 +11,23 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Queries.GetRegistrationByEma
     public class GetRegistrationByEmailQueryHandler : IRequestHandler<GetRegistrationByEmailQuery, List<Registration>>
     {
         private readonly IRegistrationContext _registrationContext;
+        private readonly ILogger<GetRegistrationByEmailQueryHandler> _logger;
 
-        public GetRegistrationByEmailQueryHandler(IRegistrationContext registrationContext)
-            => _registrationContext = registrationContext;
+        public GetRegistrationByEmailQueryHandler(IRegistrationContext registrationContext, ILogger<GetRegistrationByEmailQueryHandler> logger)
+        {
+            _registrationContext = registrationContext;
+            _logger = logger;
+        }
 
         public async Task<List<Registration>> Handle(GetRegistrationByEmailQuery request, CancellationToken cancellationToken)
         {
             var entity = await _registrationContext.FindByEmail(request.Email, cancellationToken);
 
-            if (entity == null || entity.Count == 0) return new List<Registration>();
+            if (entity == null || entity.Count == 0) 
+            {
+                _logger.LogInformation("No registration found for email: {Email}", request.Email);
+                return new List<Registration>();
+            }            
 
             return entity;
         }

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationsByAccountDetails/GetRegistrationByAccountDetailsQueryHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationsByAccountDetails/GetRegistrationByAccountDetailsQueryHandler.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Queries.GetRegistrationsByAc
                 request.DateOfBirth,
                 cancellationToken);
 
-            if (entity == null) return new List<Registration>();
+            if (entity == null || entity.Count == 0) return new List<Registration>();
 
             return entity;
         }

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationsByAccountDetails/GetRegistrationByAccountDetailsQueryHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Queries/GetRegistrationsByAccountDetails/GetRegistrationByAccountDetailsQueryHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.ApprenticeCommitments.Data;
 using SFA.DAS.ApprenticeCommitments.Data.Models;
 using System.Collections.Generic;
@@ -10,9 +11,13 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Queries.GetRegistrationsByAc
     public class GetRegistrationByAccountDetailsQueryHandler : IRequestHandler<GetRegistrationByAccountDetailsQuery, List<Registration>>
     {
         private readonly IRegistrationContext _registrationContext;
+        private readonly ILogger<GetRegistrationByAccountDetailsQueryHandler> _logger;
 
-        public GetRegistrationByAccountDetailsQueryHandler(IRegistrationContext registrationContext)
-            => _registrationContext = registrationContext;
+        public GetRegistrationByAccountDetailsQueryHandler(IRegistrationContext registrationContext, ILogger<GetRegistrationByAccountDetailsQueryHandler> logger)
+        {
+            _registrationContext = registrationContext;
+            _logger = logger;
+        }
 
         public async Task<List<Registration>> Handle(
             GetRegistrationByAccountDetailsQuery request,
@@ -24,7 +29,11 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Queries.GetRegistrationsByAc
                 request.DateOfBirth,
                 cancellationToken);
 
-            if (entity == null || entity.Count == 0) return new List<Registration>();
+            if (entity == null || entity.Count == 0) 
+            {
+                _logger.LogInformation("No registrations found for FirstName: {FirstName}, LastName: {LastName}, DateOfBirth: {DateOfBirth}", request.FirstName, request.LastName, request.DateOfBirth);
+                return new List<Registration>(); 
+            }
 
             return entity;
         }


### PR DESCRIPTION
Creates index for GetByPersonalDetails requests

remove 404 errors by returning ok if response to GetByEmail and GetByPersonalDetails returns a count of 0. This is potentially expected behaviour and we don't want to include an error on this